### PR TITLE
fix arguments parsing on platforms with unsigned char

### DIFF
--- a/src/benchmark_multiply/benchmark_multiply.cpp
+++ b/src/benchmark_multiply/benchmark_multiply.cpp
@@ -133,7 +133,7 @@ void parse_arguments(int argc, char **argv) {
             {nullptr, 0,                   nullptr, 0}
     };
 
-    char option;
+    int option;
     string tmp_str;
     while ((option = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1) {
         int ioptarg;


### PR DESCRIPTION
ARM and RISC-V are using an unsigned integer for 'char' (contrary to x86).
When getopt(_long) is done parsing the arguments, it returns a (signed)
integer with -1. If we cast it as unsigned, it never detects it properly.